### PR TITLE
Allow sharing of arbitrary files

### DIFF
--- a/share/addon_template/Share.gd
+++ b/share/addon_template/Share.gd
@@ -89,3 +89,18 @@ func share_viewport(a_viewport: Viewport, a_title: String, a_subject: String, a_
 		)
 	else:
 		printerr("%s plugin not initialized" % PLUGIN_SINGLETON_NAME)
+
+
+func share_file(a_path: String, a_mime_type: String, a_title: String, a_subject: String, a_content: String) -> void:
+	if _plugin_singleton != null:
+		_plugin_singleton.share(
+			SharedData.new()
+				.set_title(a_title)
+				.set_subject(a_subject)
+				.set_content(a_content)
+				.set_mime_type(a_mime_type)
+				.set_image_path(a_path)
+				.get_raw_data()
+		)
+	else:
+		printerr("%s plugin not initialized" % PLUGIN_SINGLETON_NAME)

--- a/share/addon_template/Share.gd
+++ b/share/addon_template/Share.gd
@@ -72,7 +72,7 @@ func share_file(a_path: String, a_mime_type: String, a_title: String, a_subject:
 				.set_subject(a_subject)
 				.set_content(a_content)
 				.set_mime_type(a_mime_type)
-				.set_image_path(a_path)
+				.set_file_path(a_path)
 				.get_raw_data()
 		)
 	else:

--- a/share/addon_template/Share.gd
+++ b/share/addon_template/Share.gd
@@ -7,6 +7,8 @@ class_name Share
 extends Node
 
 const PLUGIN_SINGLETON_NAME: String = "@pluginName@"
+const MIME_TYPE_TEXT: String = "text/plain"
+const MIME_TYPE_IMAGE: String = "image/*"
 
 @onready var _temp_image_path: String = OS.get_user_data_dir() + "/tmp_share_img_path.png"
 
@@ -37,6 +39,7 @@ func share_text(a_title: String, a_subject: String, a_content: String) -> void:
 				.set_title(a_title)
 				.set_subject(a_subject)
 				.set_content(a_content)
+				.set_mime_type(MIME_TYPE_TEXT)
 				.get_raw_data()
 		)
 	else:
@@ -44,51 +47,21 @@ func share_text(a_title: String, a_subject: String, a_content: String) -> void:
 
 
 func share_image(a_path: String, a_title: String, a_subject: String, a_content: String) -> void:
-	if _plugin_singleton != null:
-		_plugin_singleton.share(
-			SharedData.new()
-				.set_title(a_title)
-				.set_subject(a_subject)
-				.set_content(a_content)
-				.set_image_path(a_path)
-				.get_raw_data()
-		)
-	else:
-		printerr("%s plugin not initialized" % PLUGIN_SINGLETON_NAME)
+	share_file(a_path, MIME_TYPE_IMAGE, a_title, a_subject, a_content)
 
 
 func share_texture(a_texture: Texture2D, a_title: String, a_subject: String, a_content: String) -> void:
-	if _plugin_singleton != null:
-		var __image: Image = a_texture.get_image()
-		__image.save_png(_temp_image_path)
-		_plugin_singleton.share(
-			SharedData.new()
-				.set_title(a_title)
-				.set_subject(a_subject)
-				.set_content(a_content)
-				.set_image_path(_temp_image_path)
-				.get_raw_data()
-		)
-	else:
-		printerr("%s plugin not initialized" % PLUGIN_SINGLETON_NAME)
+	var __image: Image = a_texture.get_image()
+	__image.save_png(_temp_image_path)
+	share_file(_temp_image_path, MIME_TYPE_IMAGE, a_title, a_subject, a_content)
 
 
 func share_viewport(a_viewport: Viewport, a_title: String, a_subject: String, a_content: String, a_flip_y: bool = false) -> void:
-	if _plugin_singleton != null:
-		var __image: Image = a_viewport.get_texture().get_image()
-		if a_flip_y:
-			__image.flip_y()
-		__image.save_png(_temp_image_path)
-		_plugin_singleton.share(
-			SharedData.new()
-				.set_title(a_title)
-				.set_subject(a_subject)
-				.set_content(a_content)
-				.set_image_path(_temp_image_path)
-				.get_raw_data()
-		)
-	else:
-		printerr("%s plugin not initialized" % PLUGIN_SINGLETON_NAME)
+	var __image: Image = a_viewport.get_texture().get_image()
+	if a_flip_y:
+		__image.flip_y()
+	__image.save_png(_temp_image_path)
+	share_file(_temp_image_path, MIME_TYPE_IMAGE, a_title, a_subject, a_content)
 
 
 func share_file(a_path: String, a_mime_type: String, a_title: String, a_subject: String, a_content: String) -> void:

--- a/share/addon_template/model/SharedData.gd
+++ b/share/addon_template/model/SharedData.gd
@@ -8,7 +8,7 @@ extends RefCounted
 const DATA_KEY_TITLE = "title"
 const DATA_KEY_SUBJECT = "subject"
 const DATA_KEY_CONTENT = "content"
-const DATA_KEY_IMAGE_PATH = "image_path"
+const DATA_KEY_FILE_PATH = "file_path"
 const DATA_KEY_MIME_TYPE = "mime_type"
 
 var _data: Dictionary
@@ -33,8 +33,8 @@ func set_content(a_content: String) -> SharedData:
 	return self
 
 
-func set_image_path(a_image_path: String) -> SharedData:
-	_data[DATA_KEY_IMAGE_PATH] = a_image_path
+func set_file_path(a_file_path: String) -> SharedData:
+	_data[DATA_KEY_FILE_PATH] = a_file_path
 	return self
 
 

--- a/share/addon_template/model/SharedData.gd
+++ b/share/addon_template/model/SharedData.gd
@@ -9,6 +9,7 @@ const DATA_KEY_TITLE = "title"
 const DATA_KEY_SUBJECT = "subject"
 const DATA_KEY_CONTENT = "content"
 const DATA_KEY_IMAGE_PATH = "image_path"
+const DATA_KEY_MIME_TYPE = "mime_type"
 
 var _data: Dictionary
 
@@ -34,6 +35,11 @@ func set_content(a_content: String) -> SharedData:
 
 func set_image_path(a_image_path: String) -> SharedData:
 	_data[DATA_KEY_IMAGE_PATH] = a_image_path
+	return self
+
+
+func set_mime_type(a_mime_type: String) -> SharedData:
+	_data[DATA_KEY_MIME_TYPE] = a_mime_type
 	return self
 
 

--- a/share/src/main/java/org/godotengine/plugin/android/share/SharePlugin.java
+++ b/share/src/main/java/org/godotengine/plugin/android/share/SharePlugin.java
@@ -28,7 +28,6 @@ public class SharePlugin extends GodotPlugin {
 	private static final String LOG_TAG = "godot::" + CLASS_NAME;
 	private static final String FILE_PROVIDER = ".sharefileprovider";
 	private static final String MIME_TYPE_TEXT = "text/plain";
-	private static final String MIME_TYPE_IMAGE = "image/*";
 
 	private Activity activity;
 	private String authority;
@@ -46,7 +45,6 @@ public class SharePlugin extends GodotPlugin {
 		shareIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, sharedData.getSubject());
 		shareIntent.putExtra(android.content.Intent.EXTRA_TEXT, sharedData.getContent());
 
-		String mime_type = sharedData.getMimeType();
 		String path = sharedData.getImagePath();
 		if (path != null && !path.isEmpty()) {
 			File f = new File(path);
@@ -59,20 +57,17 @@ public class SharePlugin extends GodotPlugin {
 				return;
 			}
 
-			if (mime_type == null) {
-				// override mime type if none has been provided by the user
-				mime_type = MIME_TYPE_IMAGE;
-			}
 			shareIntent.setClipData(ClipData.newRawUri("", uri));
 			shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
 			shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 		}
 
+		String mime_type = sharedData.getMimeType();
 		if (mime_type != null) {
-			shareIntent.setType(mime_type);
-		} else {
-			shareIntent.setType(MIME_TYPE_TEXT);
+			// only used as fallback
+			mime_type = MIME_TYPE_TEXT;
 		}
+		shareIntent.setType(mime_type);
 
 		activity.startActivity(Intent.createChooser(shareIntent, sharedData.getTitle()));
 	}

--- a/share/src/main/java/org/godotengine/plugin/android/share/SharePlugin.java
+++ b/share/src/main/java/org/godotengine/plugin/android/share/SharePlugin.java
@@ -45,7 +45,7 @@ public class SharePlugin extends GodotPlugin {
 		shareIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, sharedData.getSubject());
 		shareIntent.putExtra(android.content.Intent.EXTRA_TEXT, sharedData.getContent());
 
-		String path = sharedData.getImagePath();
+		String path = sharedData.getFilePath();
 		if (path != null && !path.isEmpty()) {
 			File f = new File(path);
 

--- a/share/src/main/java/org/godotengine/plugin/android/share/SharePlugin.java
+++ b/share/src/main/java/org/godotengine/plugin/android/share/SharePlugin.java
@@ -46,6 +46,7 @@ public class SharePlugin extends GodotPlugin {
 		shareIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, sharedData.getSubject());
 		shareIntent.putExtra(android.content.Intent.EXTRA_TEXT, sharedData.getContent());
 
+		String mime_type = sharedData.getMimeType();
 		String path = sharedData.getImagePath();
 		if (path != null && !path.isEmpty()) {
 			File f = new File(path);
@@ -58,12 +59,18 @@ public class SharePlugin extends GodotPlugin {
 				return;
 			}
 
-			shareIntent.setType(MIME_TYPE_IMAGE);
+			if (mime_type == null) {
+				// override mime type if none has been provided by the user
+				mime_type = MIME_TYPE_IMAGE;
+			}
 			shareIntent.setClipData(ClipData.newRawUri("", uri));
 			shareIntent.putExtra(Intent.EXTRA_STREAM, uri);
 			shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 		}
-		else {
+
+		if (mime_type != null) {
+			shareIntent.setType(mime_type);
+		} else {
 			shareIntent.setType(MIME_TYPE_TEXT);
 		}
 

--- a/share/src/main/java/org/godotengine/plugin/android/share/model/SharedData.java
+++ b/share/src/main/java/org/godotengine/plugin/android/share/model/SharedData.java
@@ -10,7 +10,7 @@ public class SharedData {
 	private static String DATA_KEY_TITLE = "title";
 	private static String DATA_KEY_SUBJECT = "subject";
 	private static String DATA_KEY_CONTENT = "content";
-	private static String DATA_KEY_IMAGE_PATH = "image_path";
+	private static String DATA_KEY_FILE_PATH = "file_path";
 	private static String DATA_KEY_MIME_TYPE = "mime_type";
 
 	private Dictionary data;
@@ -31,8 +31,8 @@ public class SharedData {
 		return (String) data.get(DATA_KEY_CONTENT);
 	}
 
-	public String getImagePath() {
-		return (String) data.get(DATA_KEY_IMAGE_PATH);
+	public String getFilePath() {
+		return (String) data.get(DATA_KEY_FILE_PATH);
 	}
 
 	public String getMimeType() {

--- a/share/src/main/java/org/godotengine/plugin/android/share/model/SharedData.java
+++ b/share/src/main/java/org/godotengine/plugin/android/share/model/SharedData.java
@@ -11,6 +11,7 @@ public class SharedData {
 	private static String DATA_KEY_SUBJECT = "subject";
 	private static String DATA_KEY_CONTENT = "content";
 	private static String DATA_KEY_IMAGE_PATH = "image_path";
+	private static String DATA_KEY_MIME_TYPE = "mime_type";
 
 	private Dictionary data;
 
@@ -32,5 +33,9 @@ public class SharedData {
 
 	public String getImagePath() {
 		return (String) data.get(DATA_KEY_IMAGE_PATH);
+	}
+
+	public String getMimeType() {
+		return (String) data.get(DATA_KEY_MIME_TYPE);
 	}
 }


### PR DESCRIPTION
With this PR the share plugin can now share arbitrary files on android. This is done by letting the user of this plugin specify the mime-type themselves. Text and image sharing still set the mime-type as they did before, so this shouldn't impact existing users.

This PR (at the time of opening it) is split into three parts, please see the individual commit messages, but to summarize:
 * commit 1 implements the feature
 * commit 2 cleans up a bit of code duplication that can now be avoided by using the new `share_file()` method.
 * commit 3 renames the plugin methods from anything `image` to the more generic `file`

I thought I'd offer this in three parts so that if you think one of the steps goes to far we can just remove it from the PR, so... please let me know. :)

I implemented this so I could share sound files from my Godot app to other applications, which now seems to be working. I haven't tested the other share methods much after refactoring.

Fixes #5 