### PR TITLE
Avoid startup error message on non-Android systems

### DIFF
--- a/share/addon_template/Share.gd
+++ b/share/addon_template/Share.gd
@@ -14,7 +14,8 @@ var _plugin_singleton: Object
 
 
 func _ready() -> void:
-	_update_plugin()
+	if OS.get_name() == "Android":
+		_update_plugin()
 
 
 func _notification(a_what: int) -> void:


### PR DESCRIPTION
When running a Godot application with the share plugin enabled on a non-Android system we always get an error message:

ERROR: SharePlugin singleton not found!

As we don't have a share plugin on non-Android platform, we don't need to try to instantiate the share plugin. We do this by only calling _update_plugin() when we're on Android.